### PR TITLE
fix: PRCR2-931 sensitive data being logged into log files

### DIFF
--- a/modules/bunyan.js
+++ b/modules/bunyan.js
@@ -67,7 +67,7 @@ function Bunyan(options) {
                 logData.push(data[1]);
                 logData.push(data[0]);
             }
-            lib.transformData(logData, ((config && config.transform) || (options && options.transformData)));
+            lib.transformData(logData);
             log[level].apply(log, logData);
         }
 


### PR DESCRIPTION
Sensitive data was still found in error messages logged from joi, therefor we now iterate and mask the internals in the ValidationError object. Furthermore the configuration for keys to be masked is passed to the construction of the lib object instead of on every transformData method call. This way the regex for masking the data is constructed only once on application startup instead of on every log.