### PR TITLE
fix: streamConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docs
 test/*.log
 leveldb
 test/log/*
+node_modules

--- a/modules/bunyan.js
+++ b/modules/bunyan.js
@@ -28,7 +28,6 @@ function fixStreams(streams, workDir) {
         } else if (typeof stream.stream === 'string') {
             createStream = serverRequire(stream.stream);
             stream.streamConfig.workDir = workDir;
-            stream.type = stream.streamConfig.type;
             stream.stream = createStream(stream.streamConfig);
             delete stream.streamConfig;
         } else if (typeof stream.stream === 'function') {


### PR DESCRIPTION
The type should be outside of the streamConfig. E.g:
```
{
"log": {
        "streams": [{
            "level": "error",
            "stream": "../sentryStream",
            "streamConfig": {
                "dsn": "http://xxx:yyy@host:port/2",
                "patchGlobal": false,
                "logger": "service-customer"
            },
            "type": "raw"
        }]
    }
}
```
streamConfig contains configuration for the particular stream e.g. sentry, logshtash, etc.. while the level and the type matter for bunyan logger.

