### PR TITLE
Feat/fingerprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test/*.log
 leveldb
 test/log/*
 node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ut-bus": "^6.2.0"
   },
   "devDependencies": {
-    "ut-tools": "^5.32.8"
+    "ut-tools": "^5.32.10"
   },
   "optionalDependencies": {
     "gelf-stream": "1.1.1",

--- a/sentryStream.js
+++ b/sentryStream.js
@@ -40,7 +40,15 @@ util.inherits(SentryStream, stream.Writable);
 SentryStream.prototype._write = function(logMessage, encoding, done) {
     if (this.raven) {
         if (logMessage.jsException) {
-            this.raven.captureException(logMessage.jsException);
+            let fingerprint = ['{{ default }}'];
+            if (logMessage.jsException.type) {
+                fingerprint.push(logMessage.jsException.type);
+            }
+            this.raven.captureException(logMessage.jsException, {fingerprint}, function(sendErr, eventId) {
+                if (sendErr) {
+                    console.error('Failed to send captured exception to Sentry.', `eventId: ${eventId}`);
+                }
+            });
         } else {
             if (typeof logMessage === 'string') {
                 if (logMessage.indexOf('jsException') !== -1) { // error already sent through winston logger


### PR DESCRIPTION
Use error.type (if applicable) as a fingerprint token to allow more granular grouping. 
This is necessary for sql errors for example - they all have identical stacks so without fingeprints they are undistinguisable by sentry.