### PR TITLE
WIP: fix: Removed limitation for length of message (1024) in function tran…

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ var LibFactory = function(options) {
             }
             var message;
             if (data[0].message && data[0].message.constructor.name === 'Buffer') {
-                message = data[0].message.toString('hex', 0).toUpperCase();
+                message = data[0].message.toString('hex').toUpperCase();
             }
             data[0] = this.maskData(data[0], context);
             if (message && 'message' in data[0]) {

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ var LibFactory = function(options) {
             }
             var message;
             if (data[0].message && data[0].message.constructor.name === 'Buffer') {
-                message = data[0].message.toString('hex', 0, Math.min(data[0].message.length, 1024)).toUpperCase();
+                message = data[0].message.toString('hex', 0).toUpperCase();
             }
             data[0] = this.maskData(data[0], context);
             if (message && 'message' in data[0]) {


### PR DESCRIPTION
Removed limitation for length of message (1024) in function transformData.
This limitation was causing partial logging for longer NDC messages. I do not have enough info for the various use cases of this module, apart from NDC protocol, to decide on alternative value to 1024. 
I propose this limitation to be removed currently if this will not cause problems."

For reference on *possible* maximum length of NDC message, below you can find a note from Diebold's documentation on their implementation of Advance NDC:  

> 3.2.1 State Tables Load
> This message is used to load state tables into terminal memory. The maximum
> message length for this command is 8192 characters from header to trailer.
