### PR TITLE
Raising version of stream-file-archive module

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lodash.defaultsdeep": "4.6.0",
     "readable-stream": "2.3.3",
     "socket.io-client": "2.0.4",
-    "stream-file-archive": "1.1.3",
+    "stream-file-archive": "1.1.4",
     "uuid": "3.3.2",
     "fs-plus": "3.0.2"
   },


### PR DESCRIPTION
We need stream-file-archive@1.1.4 for a project, because of this [commit](https://github.com/brycebaril/stream-file-archive/commit/45303142007f9e64a5a0a6745992f084e456a96b).
